### PR TITLE
:sparkles:右下角添加返回顶部按钮；移动Github徽标到右上角

### DIFF
--- a/Web/index.html
+++ b/Web/index.html
@@ -67,6 +67,12 @@
             </svg>
         </a>
     </footer>
+    
+    <footer id="backToTop" class="back-to-top" title="返回顶部">
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M17 15l-5-5-5 5"/>
+        </svg>
+    </footer>
 
     <script src="db_search.js"></script>
     <script src="script.js"></script>

--- a/Web/script.js
+++ b/Web/script.js
@@ -707,3 +707,19 @@ function handleCardClick(result) {
         }
     }
 }
+// backToTop
+var button = document.getElementById('backToTop');
+button.style.display = 'none';
+window.addEventListener('scroll', function() {
+    if (window.pageYOffset > 200) {
+        button.style.display = 'block';
+    } else {
+        button.style.display = 'none';
+    }
+});
+button.addEventListener('click', function() {
+    window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+    });
+});

--- a/Web/style.css
+++ b/Web/style.css
@@ -308,8 +308,12 @@ input:focus {
 }
 
 .site-footer {
-    text-align: center;
-    padding: 2rem 0;
+    position: fixed;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 1rem;
+    z-index: 1000;
+    text-align: right;
 }
 
 .github-link {
@@ -320,6 +324,15 @@ input:focus {
 
 .github-link:hover {
     opacity: 1;
+}
+
+.back-to-top{
+    position: fixed;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    padding: 1rem;
+    z-index: 1000;
+    text-align: right;
 }
 
 @media (max-width: 640px) {

--- a/Web/style.css
+++ b/Web/style.css
@@ -314,6 +314,8 @@ input:focus {
     padding: 1rem;
     z-index: 1000;
     text-align: right;
+    backdrop-filter: blur(20px);
+    -webkit-mask: radial-gradient(closest-side circle, #000 40%, transparent 100%);
 }
 
 .github-link {
@@ -333,6 +335,8 @@ input:focus {
     padding: 1rem;
     z-index: 1000;
     text-align: right;
+    backdrop-filter: blur(20px);
+    -webkit-mask: radial-gradient(closest-side circle, #000 40%, transparent 100%);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
> 此提交已允许维护者编辑
- **新增**：在页面右下角新增了一个返回顶部的按钮。
- **仓库徽标位置修改**：
执行关键词搜索时，出来的结果条目会有很多，此时Github仓库徽标位于页面最底部，想点进仓库看看时，需要不断滚动搜索条目到最底下才能看到，这个设计可能不是很方便？所以我顺手把徽标的位置移动到了页面右上角。
<img src="https://github.com/user-attachments/assets/ac8e092a-ef0c-4686-8f0a-90c5a83eec57" width="88" />